### PR TITLE
21-show-all-paths-method

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ style: function(geoJsonFeature) {
 | --- | --- | --- |
 | `selectFeaturesForPathDisplay( selectionFeatures, selectionMode )`  | `selectionFeatures`: `Array` of origin or destination features already managed and displayed by the layer. <br/> <br/> `selectionMode`: `String`. Valid values: `'SELECTION_NEW'`, `'SELECTION_ADD'`, or `'SELECTION_SUBTRACT'`. | This informs the layer which Bezier curves should be drawn on the map. <br/><br/> For example, you can most easily use this in conjunction with a `click` or `mouseover` event listener. |
 | `selectFeaturesForPathDisplayById( uniqueOriginOrDestinationIdField, idValue, originBoolean, selectionMode )` |  | This is a convenience method if the unique origin or destination ID value is already known and you do not wish to rely on a `click` or `mouseover` event listener. |
+| `selectAllFeaturesForPathDisplay()` |  | This informs the layer to select (and thus show) all Bezier curves. |
 | `clearAllPathSelections()` |  | This informs the layer to unselect (and thus hide) all Bezier curves. |
 | `playAnimation()` |  | This starts and shows Bezier curve animations. |
 | `stopAnimation()` |  | This stops and hides any Bezier curve animations. |

--- a/docs/comparison/index.html
+++ b/docs/comparison/index.html
@@ -36,7 +36,7 @@
       margin-bottom: 25px;
       z-index: 1000;
       max-width: 350px;
-      max-height: 515px;
+      max-height: 550px;
       overflow-y: auto;
       border-top: 3px solid #33C3F0;
       border-bottom: 3px solid #33C3F0;
@@ -83,7 +83,6 @@
         width: 100%;
       }
     }
-
   </style>
 
 </head>
@@ -141,6 +140,14 @@
         </div>
       </div>
 
+      <div class="row">
+        <div class="six columns">
+          <button id="showAllPathsButton" class="u-full-width">Show All</button>
+        </div>
+        <div class="six columns">
+          <button id="clearAllPathsButton" class="u-full-width">Clear All</button>
+        </div>
+      </div>
     </div>
 
   </div>
@@ -259,6 +266,8 @@
     var pathAnimationDurationInput = document.getElementById('pathAnimationDurationInput');
     var userInteractionSelect = document.getElementById('userInteractionSelect');
     var pathSelectionTypeSelect = document.getElementById('pathSelectionTypeSelect');
+    var showAllPathsButton = document.getElementById('showAllPathsButton');
+    var clearAllPathsButton = document.getElementById('clearAllPathsButton');
 
     // establish actions for form elements in the control panel card
     oneToManyLayerButton.addEventListener('click', toggleActiveLayer);
@@ -346,6 +355,18 @@
         e.target.selectFeaturesForPathDisplay(e.sharedDestinationFeatures, pathSelectionTypeSelect.value);
       }
     }
+
+    showAllPathsButton.addEventListener('click', function() {
+      layersArray.forEach(function(layer) {
+        layer.selectAllFeaturesForPathDisplay();
+      });
+    });
+
+    clearAllPathsButton.addEventListener('click', function() {
+      layersArray.forEach(function(layer) {
+        layer.clearAllPathSelections();
+      });
+    });
 
   </script>
 

--- a/src/CanvasFlowmapLayer.js
+++ b/src/CanvasFlowmapLayer.js
@@ -399,6 +399,18 @@
       this._resetCanvas();
     },
 
+    selectAllFeaturesForPathDisplay: function() {
+      this.originAndDestinationGeoJsonPoints.features.forEach(function(feature) {
+        if (feature.properties.isOrigin) {
+          feature.properties._isSelectedForPathDisplay = true;
+        } else {
+          feature.properties._isSelectedForPathDisplay = false;
+        }
+      });
+
+      this._resetCanvas();
+    },
+
     _filterGeoJsonPointsToDraw: function(geoJsonFeatureCollection) {
       var newGeoJson = {
         type: 'FeatureCollection',
@@ -540,6 +552,11 @@
     },
 
     _resetCanvas: function() {
+      if (!this._map) {
+        // stop early if the layer is not currently on the map
+        return;
+      }
+
       // update the canvas position and redraw its content
       var topLeft = this._map.containerPointToLayerPoint([0, 0]);
       this._customCanvases.forEach(function(canvas) {


### PR DESCRIPTION
Resolves #21.  Adds new method `selectAllFeaturesForPathDisplay`. Also updated the "comparison" demo page with new buttons to test it out.

@diggydiggyhole, thanks for suggesting the enhancement and providing an idea on how to do it.